### PR TITLE
correct the asset filter syntax in the .bonsai.yml

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -6,53 +6,53 @@ builds:
   asset_filename: "#{repo}_#{version}_linux_amd64.tar.gz"
   sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
   filter:
-  -  "System.OS == linux"
-  -  "System.Arch == amd64"
+  -  "entity.system.os == 'linux'"
+  -  "entity.system.arch == 'amd64'"
 
 - platform: "linux"
   arch: "386"
   asset_filename: "#{repo}_#{version}_linux_386.tar.gz"
   sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
   filter:
-  -  "System.OS == linux"
-  -  "System.Arch == 386"
+  -  "entity.system.os == 'linux'"
+  -  "entity.system.arch == '386'"
 
 - platform: "linux"
   arch: "arm64"
   asset_filename: "#{repo}_#{version}_linux_arm64.tar.gz"
   sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
   filter:
-  -  "System.OS == linux"
-  -  "System.Arch == arm64"
+  -  "entity.system.os == 'linux'"
+  -  "entity.system.arch == 'arm64'"
 
 - platform: "linux"
   arch: "armv7"
   asset_filename: "#{repo}_#{version}_linux_armv7.tar.gz"
   sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
   filter:
-  -  "System.OS == linux"
-  -  "System.Arch == armv7"
+  -  "entity.system.os == 'linux'"
+  -  "entity.system.arch == 'armv7'"
 
 - platform: "OSX"
   arch: "amd64"
   asset_filename: "#{repo}_#{version}_darwin_amd64.tar.gz"
   sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
   filter:
-  -  "System.OS == darwin"
-  -  "System.Arch == amd64"
+  -  "entity.system.os == 'darwin'"
+  -  "entity.system.arch == 'amd64'"
 
 - platform: "OSX"
   arch: "386"
   asset_filename: "#{repo}_#{version}_darwin_386.tar.gz"
   sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
   filter:
-  -  "System.OS == darwin"
-  -  "System.Arch == 386"
+  -  "entity.system.os == 'darwin'"
+  -  "entity.system.arch == '386'"
 
 - platform: "Windows"
   arch: "amd64"
   asset_filename: "#{repo}_#{version}_windows_amd64.tar.gz"
   sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
   filter:
-  -  "System.OS == darwin"
-  -  "System.Arch == amd64"
+  -  "entity.system.os == 'windows'"
+  -  "entity.system.arch == 'amd64'"


### PR DESCRIPTION
closes #5  

Three fixes:
1) correct js syntax referencing entity.system.*
2) single quote named arch and os 
3) fix named os used for windows asset 

