### PR TITLE
Fix goreleaser to use archives instead of deprecated archive

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,12 +32,13 @@ checksum:
   # Default is `{{ .ProjectName }}_{{ .Version }}_checksums.txt`.
   name_template: "{{ .ProjectName }}_{{ .Version }}_sha256-checksums.txt"
 
-archive:
-  format: tar.gz
-  files:
-    - LICENSE
-    - README.md
-    - CHANGELOG.md
+archives:
+  - id: tar
+    format: tar.gz
+    files:
+      - LICENSE
+      - README.md
+      - CHANGELOG.md
 
   # You can change the name of the GitHub release.
   # This is parsed with the Go template engine and the following variables


### PR DESCRIPTION
goreleaser removed the depreated archive: tag as of 12/27/2019, updated to use archives.

Signed-off-by: Todd Campbell <todd@sensu.io>